### PR TITLE
Remove salt package from requirements file.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 python-etcd
-salt==2014.1
 python-dateutil==2.2
 gevent>=1.0
 greenlet>=0.3.2


### PR DESCRIPTION
Removed the requirement for salt package from gluster bridge as it is not a requirement
Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>