### PR TITLE
Fixed issues with persister and standardized etcd keys

### DIFF
--- a/tendrl/gluster_bridge/persistence/persister.py
+++ b/tendrl/gluster_bridge/persistence/persister.py
@@ -71,8 +71,8 @@ class Persister(gevent.greenlet.Greenlet):
                 except AttributeError:
                     return object.__getattribute__(self, item)
 
-    def _update_sync_object(self, updated, data):
-        self._store.save(SyncObject(updated=updated, data=data))
+    def update_sync_object(self, updated, cluster_id, data):
+        self._store.save(SyncObject(updated=updated, cluster_id=cluster_id, data=data))
 
     def _update_peer(self, peer):
         self._store.save(peer)

--- a/tendrl/gluster_bridge/persistence/persister.py
+++ b/tendrl/gluster_bridge/persistence/persister.py
@@ -72,7 +72,13 @@ class Persister(gevent.greenlet.Greenlet):
                     return object.__getattribute__(self, item)
 
     def update_sync_object(self, updated, cluster_id, data):
-        self._store.save(SyncObject(updated=updated, cluster_id=cluster_id, data=data))
+        self._store.save(
+            SyncObject(
+                updated=updated,
+                cluster_id=cluster_id,
+                data=data
+            )
+        )
 
     def _update_peer(self, peer):
         self._store.save(peer)

--- a/tendrl/gluster_bridge/persistence/servers.py
+++ b/tendrl/gluster_bridge/persistence/servers.py
@@ -6,15 +6,16 @@ class Peer(EtcdObj):
     """A table of the peers seen by the pull, lazily updated
 
     """
-    __name__ = 'clusters/gluster/%s/peers/%s'
+    __name__ = 'clusters/%s/peers/%s'
 
+    cluster_id = fields.StrField("cluster_id")
     state = fields.StrField("state")
     hostname = fields.StrField("hostname")
     peer_uuid = fields.StrField("peer_uuid")
     updated = fields.StrField("updated")
 
     def render(self):
-        self.__name__ = self.__name__ % self.peer_uuid
+        self.__name__ = self.__name__ % (self.cluster_id, self.peer_uuid)
         return super(Peer, self).render()
 
 
@@ -22,8 +23,9 @@ class Volume(EtcdObj):
     """A table of the volumes seen by the pull.
 
     """
-    __name__ = 'clusters/gluster/%s/volumes/%s'
+    __name__ = 'clusters/%s/volumes/%s'
 
+    cluster_id = fields.StrField("cluster_id")
     vol_id = fields.StrField("vol_id")
     vol_type = fields.StrField("vol_type")
     name = fields.StrField("name")
@@ -31,7 +33,7 @@ class Volume(EtcdObj):
     brick_count = fields.StrField("brick_count")
 
     def render(self):
-        self.__name__ = self.__name__ % self.vol_id
+        self.__name__ = self.__name__ % (self.cluster_id, self.vol_id)
         return super(Volume, self).render()
 
 
@@ -39,8 +41,9 @@ class Brick(EtcdObj):
     """A table of the volumes seen by the pull.
 
     """
-    __name__ = 'clusters/gluster/%s/bricks/%s'
+    __name__ = 'clusters/%s/volumes/%s/bricks/%s'
 
+    cluster_id = fields.StrField("cluster_id")
     vol_id = fields.StrField("vol_id")
     path = fields.StrField("path")
     hostname = fields.StrField("hostname")
@@ -50,5 +53,9 @@ class Brick(EtcdObj):
     mount_opts = fields.StrField("mount_opts")
 
     def render(self):
-        self.__name__ = self.__name__ % (self.path.replace("/", "_"))
+        self.__name__ = self.__name__ % (
+            self.cluster_id,
+            self.vol_id,
+            self.path.replace("/", "_")
+        )
         return super(Brick, self).render()

--- a/tendrl/gluster_bridge/persistence/sync_objects.py
+++ b/tendrl/gluster_bridge/persistence/sync_objects.py
@@ -8,7 +8,12 @@ class SyncObject(EtcdObj):
     cluster maps.
 
     """
-    __name__ = 'clusters/gluster/%s/raw_map'
+    __name__ = 'clusters/%s/raw_map'
 
+    cluster_id = fields.StrField("cluster_id")
     data = fields.StrField("data")
     updated = fields.StrField("updated")
+
+    def render(self):
+        self.__name__ = self.__name__ % self.cluster_id
+        return super(SyncObject, self).render()

--- a/tendrl/gluster_bridge/tests/test_manager.py
+++ b/tendrl/gluster_bridge/tests/test_manager.py
@@ -12,13 +12,15 @@ class Test_manager(TestGluster_bridge):
 
     def test_manager_with_peer(self):
         body = """[Global]\nMYUUID=145b9021-d47c-4094-957b-7545e8232ab7 \
-        \nop-version:40000\n[Peers]\npeer1.uuid=1\npeer1.hostname=pytest" \
+        \nop-version:40000\n[Peers]\npeer1.uuid=1\npeer1.hostnames=pytest" \
+        \nPeer1.primary_hostname=host1" \
         \npeer1.state=active"""
         self.Initialize(body)
         self.Manager.time.time = MagicMock(return_value=1477237162.990813)
         self.managerobj._discovery_thread._run()
         self.Manager.Peer.assert_called_with(
-            hostname='pytest"', peer_uuid='1', state='active',
+            cluster_id='145b9021-d47c-4094-957b-7545e8232ab7',
+            hostname='host1"', peer_uuid='1', state='active',
             updated='1477237162.99'
             )
 
@@ -29,7 +31,8 @@ class Test_manager(TestGluster_bridge):
         self.Initialize(body)
         self.managerobj._discovery_thread._run()
         self.Manager.Volume.assert_called_with(
-            brick_count='1', name='brick1', status='active',
+            brick_count='1', cluster_id='145b9021-d47c-4094-957b-7545e8232ab7',
+            name='brick1', status='active',
             vol_id='1', vol_type='abc"'
             )
 
@@ -44,6 +47,7 @@ class Test_manager(TestGluster_bridge):
         self.Initialize(body)
         self.managerobj._discovery_thread._run()
         self.Manager.Brick.assert_called_with(
+            cluster_id='145b9021-d47c-4094-957b-7545e8232ab7',
             filesystem_type='FAT12', hostname='abc', mount_options='abc',
             path='/tmp', port='80', status='active', vol_id='1'
             )

--- a/tendrl/gluster_bridge/tests/test_persister.py
+++ b/tendrl/gluster_bridge/tests/test_persister.py
@@ -47,7 +47,10 @@ class Test_Persister(object):
         """Sending dummy parameters"""
         data = "data"
         updated = "updated"
-        self.Persister._update_sync_object(updated, data)
+        self.Persister.update_sync_object(
+            updated,
+            '145b9021-d47c-4094-957b-7545e8232ab7',
+            data)
         self.Persister._store.save.assert_called()
 
     def test_update_peer(self):

--- a/tendrl/gluster_bridge/tests/test_servers.py
+++ b/tendrl/gluster_bridge/tests/test_servers.py
@@ -4,27 +4,32 @@ from tendrl.gluster_bridge.persistence import servers
 class Test_Peer(object):
     def test_peer(self):
         self.peer = servers.Peer()
-        self.peer.__name__ = 'clusters/gluster/peers/%s'
         assert self.peer.render() == [
             {
+                'name': 'cluster_id',
+                'key': '/clusters/None/peers/None/cluster_id',
+                'dir': False,
+                'value': None
+            },
+            {
                 'name': 'hostname',
-                'key': '/clusters/gluster/peers/None/hostname',
+                'key': '/clusters/None/peers/None/hostname',
                 'dir': False,
                 'value': None
             },
             {
                 'name': 'peer_uuid',
-                'key': '/clusters/gluster/peers/None/peer_uuid',
+                'key': '/clusters/None/peers/None/peer_uuid',
                 'dir': False, 'value': None
             },
             {
                 'name': 'state',
-                'key': '/clusters/gluster/peers/None/state',
+                'key': '/clusters/None/peers/None/state',
                 'dir': False, 'value': None
             },
             {
                 'name': 'updated',
-                'key': '/clusters/gluster/peers/None/updated',
+                'key': '/clusters/None/peers/None/updated',
                 'dir': False,
                 'value': None
             }]
@@ -33,35 +38,40 @@ class Test_Peer(object):
 class Test_Volume(object):
     def test_volume(self):
         self.volume = servers.Volume()
-        self.volume.__name__ = 'clusters/gluster/volumes/%s'
         assert self.volume.render() == [
             {
                 'dir': False,
                 'name': 'brick_count',
-                'key': '/clusters/gluster/volumes/None/brick_count',
+                'key': '/clusters/None/volumes/None/brick_count',
+                'value': None
+            },
+            {
+                'dir': False,
+                'name': 'cluster_id',
+                'key': '/clusters/None/volumes/None/cluster_id',
                 'value': None
             },
             {
                 'dir': False,
                 'name': 'name',
-                'key': '/clusters/gluster/volumes/None/name',
+                'key': '/clusters/None/volumes/None/name',
                 'value': None
             },
             {
                 'dir': False,
                 'name': 'status',
-                'key': '/clusters/gluster/volumes/None/status',
+                'key': '/clusters/None/volumes/None/status',
                 'value': None},
             {
                 'dir': False,
                 'name': 'vol_id',
-                'key': '/clusters/gluster/volumes/None/vol_id',
+                'key': '/clusters/None/volumes/None/vol_id',
                 'value': None
             },
             {
                 'dir': False,
                 'name': 'vol_type',
-                'key': '/clusters/gluster/volumes/None/vol_type',
+                'key': '/clusters/None/volumes/None/vol_type',
                 'value': None
             }]
 
@@ -70,47 +80,60 @@ class Test_Brick(object):
     def test_brick(self):
         self.brick = servers.Brick()
         self.brick.path = "/test/pytest"
-        self.brick.__name__ = 'clusters/gluster/bricks/%s'
         assert self.brick.render() == [
+            {
+                'name': 'cluster_id',
+                'key': '/clusters/None/volumes/None/bricks/_test_pytest/'
+                'cluster_id',
+                'dir': False,
+                'value': None
+            },
             {
                 'name': 'fs_type',
                 'value': None,
                 'dir': False,
-                'key': '/clusters/gluster/bricks/_test_pytest/fs_type'
+                'key': '/clusters/None/volumes/None/bricks/_test_pytest/'
+                'fs_type'
             },
             {
                 'name': 'hostname',
                 'value': None,
                 'dir': False,
-                'key': '/clusters/gluster/bricks/_test_pytest/hostname'
+                'key': '/clusters/None/volumes/None/bricks/_test_pytest/'
+                'hostname'
             },
             {
                 'name': 'mount_opts',
                 'value': None,
                 'dir': False,
-                'key': '/clusters/gluster/bricks/_test_pytest/mount_opts'
+                'key': '/clusters/None/volumes/None/bricks/_test_pytest/'
+                'mount_opts'
             },
             {
                 'name': 'path',
                 'value': '/test/pytest',
                 'dir': False,
-                'key': '/clusters/gluster/bricks/_test_pytest/path'
+                'key': '/clusters/None/volumes/None/bricks/_test_pytest/'
+                'path'
             },
             {
                 'name': 'port',
                 'value': None,
                 'dir': False,
-                'key': '/clusters/gluster/bricks/_test_pytest/port'
+                'key': '/clusters/None/volumes/None/bricks/_test_pytest/'
+                'port'
             },
             {
                 'name': 'status',
                 'value': None,
                 'dir': False,
-                'key': '/clusters/gluster/bricks/_test_pytest/status'
+                'key': '/clusters/None/volumes/None/bricks/_test_pytest/'
+                'status'
             },
             {
                 'name': 'vol_id',
                 'value': None,
                 'dir': False,
-                'key': '/clusters/gluster/bricks/_test_pytest/vol_id'
+                'key': '/clusters/None/volumes/None/bricks/_test_pytest/'
+                'vol_id'
             }]


### PR DESCRIPTION
There were various below listed issues which are fixed
as part of this patch
 - raw_data for the cluster was not getting written to
   etcd due to argument replacement issue
 - render() was missing in class SyncObject
 - no cluster id getting used in etcd keys
 - primary hostname is used as peer name
 - the function update_sync_object() was not referred with
   correct name in manager.py

Also standardized the etcd keys as below
 - /clusters/<cluster-id>/peers/<peer-id>
 - /clusters/<cluster-id>/volumes/<volume-id>
 - /clusters/<cluster-id>/volumes/<volume-id>/bricks/<brick-id>
 - /clusters/<cluster-id>/raw_data

Signed-off-by: Shubhendu <shtripat@redhat.com>